### PR TITLE
Tackle page headers and Apply/Done on bottom

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/widgets/OptionListWidget.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/widgets/OptionListWidget.java
@@ -4,12 +4,16 @@ import net.caffeinemc.mods.sodium.client.config.structure.Option;
 import net.caffeinemc.mods.sodium.client.config.structure.OptionGroup;
 import net.caffeinemc.mods.sodium.client.config.structure.OptionPage;
 import net.caffeinemc.mods.sodium.client.gui.ColorTheme;
+import net.caffeinemc.mods.sodium.client.gui.Colors;
 import net.caffeinemc.mods.sodium.client.gui.Layout;
 import net.caffeinemc.mods.sodium.client.gui.options.control.AbstractOptionList;
 import net.caffeinemc.mods.sodium.client.util.Dim2i;
+import net.minecraft.client.gui.ComponentPath;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.navigation.FocusNavigationEvent;
 import net.minecraft.client.gui.screens.Screen;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class OptionListWidget extends AbstractOptionList {
     private final OptionPage page;
@@ -35,6 +39,13 @@ public class OptionListWidget extends AbstractOptionList {
 
         int entryHeight = this.font.lineHeight * 2;
         int listHeight = 0;
+
+        var header = new HeaderWidget(this, new Dim2i(x, y + listHeight, width, entryHeight), this.page.name().getString(), this.theme.themeLighter);
+        this.addRenderableChild(header);
+
+        maxWidth = Math.max(maxWidth, header.getContentWidth());
+        listHeight += entryHeight + Layout.INNER_MARGIN;
+
         for (OptionGroup group : this.page.groups()) {
             // Add each option's control element
             for (Option option : group.options()) {
@@ -62,5 +73,44 @@ public class OptionListWidget extends AbstractOptionList {
         graphics.enableScissor(this.getX(), this.getY(), this.getLimitX(), this.getLimitY());
         super.render(graphics, mouseX, mouseY, delta);
         graphics.disableScissor();
+    }
+
+    public static class HeaderWidget extends AbstractWidget {
+        protected final AbstractOptionList list;
+        private final String title;
+        private final int themeColor;
+
+        public HeaderWidget(AbstractOptionList list, Dim2i dim, String title, int themeColor) {
+            super(dim);
+            this.list = list;
+            this.title = title;
+            this.themeColor = themeColor;
+        }
+
+        public int getContentWidth() {
+            return 70;
+        }
+
+        @Override
+        public void render(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+            this.hovered = this.isMouseOver(mouseX, mouseY);
+
+            this.drawRect(graphics, this.getX(), this.getY(), this.getLimitX(), this.getLimitY(), Colors.BACKGROUND_DEFAULT);
+            this.drawString(graphics, this.truncateLabelToFit(this.title), this.getX() + 6, this.getCenterY() - 4, this.themeColor);
+        }
+
+        private String truncateLabelToFit(String name) {
+            return truncateTextToFit(name, this.getWidth() - 12);
+        }
+
+        @Override
+        public int getY() {
+            return super.getY() - this.list.getScrollAmount();
+        }
+
+        @Override
+        public @Nullable ComponentPath nextFocusPath(FocusNavigationEvent event) {
+            return null;
+        }
     }
 }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/widgets/ScrollableTooltip.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/widgets/ScrollableTooltip.java
@@ -145,6 +145,9 @@ public class ScrollableTooltip {
         int arrowX = this.visibleDim.x() - ARROW_WIDTH;
         int arrowY = this.hoveredElement.getCenterY() - (ARROW_HEIGHT / 2);
 
+        graphics.pose().pushPose();
+        graphics.pose().translate(0.0F, 0.0F, 400.0F);
+
         // parameters are: render type, sprite, x, y, u offset, v offset, render width, render height, u size, v size, color
         graphics.blit(RenderType::guiTextured, ARROW_TEXTURE, arrowX, arrowY, ARROW_WIDTH, 0, ARROW_WIDTH, ARROW_HEIGHT, SPRITE_WIDTH, ARROW_HEIGHT, Colors.BACKGROUND_LIGHT);
         graphics.blit(RenderType::guiTextured, ARROW_TEXTURE, arrowX, arrowY, 0, 0, ARROW_WIDTH, ARROW_HEIGHT, SPRITE_WIDTH, ARROW_HEIGHT, Colors.BACKGROUND_DEFAULT);
@@ -158,12 +161,14 @@ public class ScrollableTooltip {
 
         graphics.enableScissor(this.visibleDim.x(), this.visibleDim.y(), this.visibleDim.getLimitX(), this.visibleDim.getLimitY());
         graphics.fill(this.visibleDim.x(), this.visibleDim.y(), this.visibleDim.getLimitX(), this.visibleDim.getLimitY(), Colors.BACKGROUND_LIGHT);
+        graphics.pose().translate(0.0F, 0.0F, 400.0F);
         for (int i = 0; i < this.content.size(); i++) {
             graphics.drawString(this.font, this.content.get(i),
                     this.visibleDim.x() + TEXT_HORIZONTAL_PADDING, this.visibleDim.y() + TEXT_VERTICAL_PADDING + (i * lineHeight) - scrollAmount,
                     Colors.FOREGROUND);
         }
         graphics.disableScissor();
+        graphics.pose().popPose();
     }
 
     public boolean mouseScrolled(double d, double e, double amount) {


### PR DESCRIPTION
This attempts to tackle the following things:

- Headers for each page in the to-be-unified options list
- The moving of the Apply/Done buttons to the bottom

To do so, few tricks were done, such as Z offsets for tooltips in order to guarantee that anything underneath it is somewhat readable, as well as the adaptation of the layout in order to accommodate the moved buttons in case of a cramped screen size.

Here's it in action (I hope a video won't be much of a problem): [Showcase](https://github.com/user-attachments/assets/2a8608a4-1f40-4a8a-bc3c-b33d1d92196d)

While there are other things to do, I'd rather cut progress into reviewable pieces than effectively doing an "Ennui's Sodium Config Screen" mod in form of a PR