### PR TITLE
fix: don't show fabulous on unsupported systems

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumConfigBuilder.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumConfigBuilder.java
@@ -439,11 +439,12 @@ public class SodiumConfigBuilder implements ConfigEntryPoint {
                                         Component.translatable("options.graphics.fancy"),
                                         Component.translatable("options.graphics.fabulous")))
                                 .setDefaultValue(GraphicsStatus.FANCY)
-                                .setAllowedValues(
-                                        Minecraft.getInstance().isRunning() && !Minecraft.getInstance().getGpuWarnlistManager().isSkippingFabulous() ?
-                                                Set.of(GraphicsStatus.FAST, GraphicsStatus.FANCY) :
-                                                Set.of(GraphicsStatus.values())
-                                )
+                                .setAllowedValuesProvider(state -> {
+                                    if (Minecraft.getInstance().isRunning() && Minecraft.getInstance().getGpuWarnlistManager().isSkippingFabulous()) {
+                                        return Set.of(GraphicsStatus.FAST, GraphicsStatus.FANCY);
+                                    }
+                                    return Set.of(GraphicsStatus.values());
+                                })
                                 .setBinding(this.vanillaOpts.graphicsMode()::set, this.vanillaOpts.graphicsMode()::get)
                                 .setImpact(OptionImpact.HIGH)
                                 .setFlags(OptionFlag.REQUIRES_RENDERER_RELOAD)

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumConfigBuilder.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumConfigBuilder.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Optional;
+import java.util.Set;
 
 // TODO: get initialValue from the vanilla options (it's private)
 public class SodiumConfigBuilder implements ConfigEntryPoint {
@@ -438,6 +439,11 @@ public class SodiumConfigBuilder implements ConfigEntryPoint {
                                         Component.translatable("options.graphics.fancy"),
                                         Component.translatable("options.graphics.fabulous")))
                                 .setDefaultValue(GraphicsStatus.FANCY)
+                                .setAllowedValues(
+                                        Minecraft.getInstance().isRunning() && !Minecraft.getInstance().getGpuWarnlistManager().isSkippingFabulous() ?
+                                                Set.of(GraphicsStatus.FAST, GraphicsStatus.FANCY) :
+                                                Set.of(GraphicsStatus.values())
+                                )
                                 .setBinding(this.vanillaOpts.graphicsMode()::set, this.vanillaOpts.graphicsMode()::get)
                                 .setImpact(OptionImpact.HIGH)
                                 .setFlags(OptionFlag.REQUIRES_RENDERER_RELOAD)


### PR DESCRIPTION
Vanilla hides "Fabulous!" on unsupported GPU's, this simply copies the check used by vanilla.
Works correctly even when the value is set to fabulous through options.txt, the sodium menu will simply display "Fabulous!", then when pressed skip to fancy -> fast -> fancy -> fast -> ...

See also https://github.com/CaffeineMC/sodium/pull/3084